### PR TITLE
Allowing String Interpolation

### DIFF
--- a/lib/markdown-rails/engine.rb
+++ b/lib/markdown-rails/engine.rb
@@ -9,7 +9,7 @@ module MarkdownRails
 
     def call(template)
       # Return Ruby code that returns the compiled template
-      MarkdownRails.renderer.call(template.source).inspect + '.html_safe'
+      '"' + MarkdownRails.renderer.call(template.source).gsub(/"/, '\"') + '".html_safe'
     end
   end
 


### PR DESCRIPTION
This change removes the call to String#inspect, manually escapes double-quote characters, and wraps the string in double-quote characters.

It is a very limited implementation because interpolation happens after Markdown. What should happen is that interpolation should occur first and then Markdown. The order is a problem because the un-interpolated Ruby code confuses the Markdown processor.
