### PR TITLE
Remove ad for gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Stackoverflow](http://stackoverflow.com/a/10131299/525872).**
 
 # markdown-rails
 
-[![Dependency Status](https://gemnasium.com/joliss/markdown-rails.png)](https://gemnasium.com/joliss/markdown-rails)
-
 This gem allows you to write static Rails views and partials using the
 [Markdown](http://daringfireball.net/projects/markdown/syntax) syntax. No more
 editing prose in HTML!


### PR DESCRIPTION
GitLab acquired the project providing dependency status, so this badge is simply an ad to migrate to GitLab now.