### PR TITLE
Add source argument to Handler for compatibility with Rails 6+

### DIFF
--- a/lib/markdown-rails/engine.rb
+++ b/lib/markdown-rails/engine.rb
@@ -7,9 +7,9 @@ module MarkdownRails
     def initialize
     end
 
-    def call(template)
+    def call(template, source = template.source)
       # Return Ruby code that returns the compiled template
-      MarkdownRails.renderer.call(template.source).inspect + '.html_safe'
+      MarkdownRails.renderer.call(source).inspect + '.html_safe'
     end
   end
 


### PR DESCRIPTION
Rails 6 now has a deprecation warning that single-arity templates will not be supported in the future. The separate, additional argument is the source of the template so that template compilers can treat the template object's `source` as immutable.

cf. https://github.com/rails/rails/pull/35119